### PR TITLE
Don't merge: process stream commands also when stream is paused (hotfix stream ejection)

### DIFF
--- a/src/backends/pipewire/stream.rs
+++ b/src/backends/pipewire/stream.rs
@@ -16,14 +16,13 @@ use pipewire::keys;
 use pipewire::main_loop::{MainLoop, WeakMainLoop};
 use pipewire::properties::Properties;
 use pipewire::stream::{Stream, StreamFlags};
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::fmt;
 use std::fmt::Formatter;
 use std::ops::DerefMut;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex, TryLockError};
 use std::thread::JoinHandle;
 use std::time::Duration;
+use std::{fmt, thread};
 
 enum StreamCommands<Callback> {
     ReceiveCallback(Callback),
@@ -160,7 +159,7 @@ impl<Callback: 'static + Send> StreamHandle<Callback> {
             + 'static,
     ) -> Result<Self, PipewireError> {
         let (mut tx, rx) = rtrb::RingBuffer::new(16);
-        let handle = std::thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let main_loop = MainLoop::new(None)?;
             let context = Context::new(&main_loop)?;
             let core = context.connect(None)?;
@@ -195,14 +194,16 @@ impl<Callback: 'static + Send> StreamHandle<Callback> {
                 config,
                 timestamp: Timestamp::new(config.samplerate),
             };
-            // Note> Rc<RefCell<T>> is a form of single-threaded analogy to Arc<Mutex<T>>.
-            let stream_inner = Rc::new(RefCell::new(stream_inner));
+            // NB(strohel): pipewire-rs API is unsound: it doesn't require the callbacks to be Send
+            // nor Sync, yet it calls them from different threads (verified empirically). Use
+            // Arc, Mutex for thread safety, even though Rc, RefCell would typecheck.
+            let stream_inner = Arc::new(Mutex::new(stream_inner));
 
             let _listener = stream
-                .add_local_listener_with_user_data(Rc::clone(&stream_inner))
+                .add_local_listener_with_user_data(Arc::clone(&stream_inner))
                 .process(move |stream, inner| {
-                    log::debug!("Processing stream");
-                    let mut inner = inner.borrow_mut();
+                    log::debug!("Processing stream from thread {:?}", thread::current().id());
+                    let mut inner = inner.lock().expect("not poisoned");
                     inner.handle_commands();
                     if inner.ejected() {
                         return;
@@ -245,7 +246,10 @@ impl<Callback: 'static + Send> StreamHandle<Callback> {
                 StreamFlags::AUTOCONNECT | StreamFlags::MAP_BUFFERS | StreamFlags::RT_PROCESS,
                 &mut params,
             )?;
-            log::debug!("Starting Pipewire main loop");
+            log::debug!(
+                "Starting Pipewire main loop on thread {:?}",
+                thread::current().id()
+            );
 
             // NB(strohel): this is a hack that enables processing commands (like Eject to stop the
             // stream) even when the stream callback is not being called (perhaps because the
@@ -253,10 +257,20 @@ impl<Callback: 'static + Send> StreamHandle<Callback> {
             let timer_source = main_loop
                 .loop_()
                 .add_timer(move |_expirations_since_last_called| {
-                    let mut inner = stream_inner.borrow_mut();
-                    if !inner.commands.is_empty() {
-                        log::debug!("Handling stream commands from a timer callback.");
-                        inner.handle_commands();
+                    log::debug!("Timer callback from thread {:?}", thread::current().id());
+                    match stream_inner.try_lock() {
+                        Ok(mut inner) => {
+                            if !inner.commands.is_empty() {
+                                log::debug!("Handling stream commands from a timer callback");
+                                inner.handle_commands();
+                            }
+                        }
+                        // Nothing to do in this case, stream callback must be holding the mutex,
+                        // no need to process the commands.
+                        Err(TryLockError::WouldBlock) => {}
+                        Err(TryLockError::Poisoned(_)) => {
+                            panic!("stream inner mutex should not be poisoned");
+                        }
                     }
                 });
             timer_source.update_timer(Some(Duration::from_secs(1)), Some(Duration::from_secs(1)));


### PR DESCRIPTION
Not intended for merging, but should be good for our use in tonari (at least short-term until a upstreamable solution is devised).

- relates to https://github.com/tonarino/interflow/pull/4 which has some WIP debugging.
- used in https://github.com/tonarino/portal/pull/5574 (internal link)
- transitively for https://github.com/tonarino/portal/issues/5329 (internal link)